### PR TITLE
Fix for IE8

### DIFF
--- a/wp-defer-loading.php
+++ b/wp-defer-loading.php
@@ -119,7 +119,10 @@ class WP_Scripts2 extends WP_Scripts
 
 
 		echo "var element = document.createElement(\"script\");\n";
-        echo "element.text( \"". addslashes(str_replace(array('\r\n','\n','\r'),"",$output)) ."\" );";
+	// <script> elements in IE8 do not support the .appendChild() method
+	// so, we're assigning the string to the .text property
+	//echo "element.appendChild( document.createTextNode( \"". addslashes(str_replace(array('\r\n','\n','\r'),"",$output)) ."\" ) );";
+	echo "element.text = '". addslashes(str_replace(array('\r\n','\n','\r'),"",$output)) ."' ;";
 		echo "\ndocument.body.appendChild(element);\n";
 
 		return true;

--- a/wp-defer-loading.php
+++ b/wp-defer-loading.php
@@ -119,7 +119,7 @@ class WP_Scripts2 extends WP_Scripts
 
 
 		echo "var element = document.createElement(\"script\");\n";
-        echo "element.appendChild( document.createTextNode( \"". addslashes(str_replace(array('\r\n','\n','\r'),"",$output)) ."\" ) );";
+        echo "element.text( \"". addslashes(str_replace(array('\r\n','\n','\r'),"",$output)) ."\" );";
 		echo "\ndocument.body.appendChild(element);\n";
 
 		return true;


### PR DESCRIPTION
> `appendChild()` in IE is not applied to `<script>`-elements (http://stackoverflow.com/a/7091055)

This pull request fixes this issue by assigning a string using the `.text` property instead.